### PR TITLE
fix: remove `frappe` dependency to support package managers

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-frappe
 python-telegram-bot


### PR DESCRIPTION
Package managers such as Pipenv and Poetry can't install work with apps that have this package in requirements. This happens because `frappe` — differnet package — is in PyPi index: https://pypi.org/project/frappe/. And pip fails to install cause it is outdated. So, solution is to remove `frappe` from requirements.