### PR TITLE
fix: not showing send to telegram

### DIFF
--- a/erpnext_telegram_integration/public/js/erpnext_telegram_integration.js
+++ b/erpnext_telegram_integration/public/js/erpnext_telegram_integration.js
@@ -4,7 +4,7 @@ $(document).on('app_ready', function() {
         var route = frappe.get_route();
 
         if (route[0] == "Form") {
-            frappe.ui.form.on(route[1], {
+            frappe.ui.form.on(route[1], 
                function (frm) {
                     cur_frm.page.add_menu_item(__("Send To Telegram"), function() {
                         var user_name = frappe.user.name;
@@ -65,8 +65,7 @@ $(document).on('app_ready', function() {
                         dialog.fields_dict.ht.$wrapper.html(reference_name);
                         dialog.show();
                     });
-                }
-            })
+                })
  
 
         }

--- a/erpnext_telegram_integration/public/js/erpnext_telegram_integration.js
+++ b/erpnext_telegram_integration/public/js/erpnext_telegram_integration.js
@@ -5,7 +5,7 @@ $(document).on('app_ready', function() {
 
         if (route[0] == "Form") {
             frappe.ui.form.on(route[1], {
-                refresh: function (frm) {
+               function (frm) {
                     cur_frm.page.add_menu_item(__("Send To Telegram"), function() {
                         var user_name = frappe.user.name;
                         var user_full_name = frappe.session.user_fullname;


### PR DESCRIPTION
this fixes the send to telegram not showing in the menu.

refresh is used in webhooks, not ajax.