### PR TITLE
fix: not needed

### DIFF
--- a/erpnext_telegram_integration/erpnext_telegram_integration/doctype/telegram_notification/telegram_notification.py
+++ b/erpnext_telegram_integration/erpnext_telegram_integration/doctype/telegram_notification/telegram_notification.py
@@ -183,12 +183,10 @@ def get_context(context):
                     else:
                         break
 
-                filters = (
-                    {
+                filters = {
                         "party": party,
                         "telegram_user": doc.get(d["fieldname"]),
-                    },
-                )
+                    }
                 telegram_user_list = frappe.get_all(
                     "Telegram User Settings",
                     filters=filters,


### PR DESCRIPTION
the list only ensures that also filters ={} is used, so all possible matches end up being searched 👍 

In [16]: frappe.get_all(
    ...:                     "Telegram User Settings",
    ...:                     filters=({'party': 'Employee', 'telegram_user': 'EMP/0004'},),
    ...:                     fields=["name", "telegram_settings", "telegram_user"],
    ...:                 )
Out[16]:
[{'name': 'EMP/0002-JvTbv_ERPBot',
  'telegram_settings': 'JvTbv_ERPBot',
  'telegram_user': 'EMP/0002'}]


In [17]: frappe.get_all(
    ...:                     "Telegram User Settings",
    ...:                     filters={'party': 'Employee', 'telegram_user': 'EMP/0004'},
    ...:                     fields=["name", "telegram_settings", "telegram_user"],
    ...:                 )
Out[17]: []